### PR TITLE
Cleanup and more tests

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -1,0 +1,61 @@
+package cnfgfile
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+/*** This code also exists in the golift.io/cnfg package. It is identical. ***/
+
+// Duration is useful if you need to load a time Duration from a config file into
+// your application. Use the config.Duration type to support automatic unmarshal
+// from all sources.
+type Duration struct{ time.Duration }
+
+// UnmarshalText parses a duration type from a config file. This method works
+// with the Duration type to allow unmarshaling of durations from files and
+// env variables in the same struct. You won't generally call this directly.
+func (d *Duration) UnmarshalText(b []byte) error {
+	dur, err := time.ParseDuration(string(b))
+	if err != nil {
+		return fmt.Errorf("parsing duration '%s': %w", b, err)
+	}
+
+	d.Duration = dur
+
+	return nil
+}
+
+// MarshalText returns the string representation of a Duration. ie. 1m32s.
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(d.Duration.String()), nil
+}
+
+// MarshalJSON returns the string representation of a Duration for JSON. ie. "1m32s".
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + d.Duration.String() + `"`), nil
+}
+
+// String returns a Duration as string without trailing zero units.
+func (d Duration) String() string {
+	dur := d.Duration.String()
+	if len(dur) > 3 && dur[len(dur)-3:] == "m0s" {
+		dur = dur[:len(dur)-2]
+	}
+
+	if len(dur) > 3 && dur[len(dur)-3:] == "h0m" {
+		dur = dur[:len(dur)-2]
+	}
+
+	return dur
+}
+
+// Make sure our struct satisfies the interface it's for.
+var (
+	_ encoding.TextUnmarshaler = (*Duration)(nil)
+	_ encoding.TextMarshaler   = (*Duration)(nil)
+	_ json.Marshaler           = (*Duration)(nil)
+	_ fmt.Stringer             = (*Duration)(nil)
+)

--- a/file.go
+++ b/file.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	toml "github.com/BurntSushi/toml"
 	yaml "gopkg.in/yaml.v3"
@@ -29,27 +28,8 @@ import (
 // Errors this library may produce.
 var (
 	ErrNoFile = errors.New("must provide at least 1 file to unmarshal")
-	ErrNotPtr = errors.New("must provide a pointer to a struct")
+	ErrNotPtr = errors.New("ReadConfigs: must provide a pointer to a struct")
 )
-
-// Duration allows unmarshalling time durations from a config file.
-type Duration struct {
-	time.Duration
-}
-
-// UnmarshalText parses a duration type from a config file. This method works
-// with the Duration type to allow unmarshaling of durations from files and
-// env variables in the same struct. You won't generally call this directly.
-func (d *Duration) UnmarshalText(b []byte) error {
-	dur, err := time.ParseDuration(string(b))
-	if err != nil {
-		return fmt.Errorf("parsing duration '%s': %w", b, err)
-	}
-
-	d.Duration = dur
-
-	return nil
-}
 
 // Unmarshal parses a configuration file (of any format) into a config struct.
 // This is a shorthand method for calling Unmarshal against the json, xml, yaml

--- a/file_test.go
+++ b/file_test.go
@@ -186,5 +186,5 @@ func ExampleUnmarshal() {
 	}
 
 	fmt.Printf("interval: %v, location: %v, provided: %v", config.Interval, config.Location, config.Provided)
-	// Output: interval: 5m0s, location: Earth, provided: true
+	// Output: interval: 5m, location: Earth, provided: true
 }

--- a/filepath_test.go
+++ b/filepath_test.go
@@ -31,10 +31,16 @@ type dataStruct struct {
 	Named   *Struct
 	Map     map[string]string
 	MapI    map[int]string
+	LulWut  map[interface{}][]*Struct
 	Strings []string
 	Structs []Struct
 	Ptructs []*Struct
+	Etring  String
+	String
+	StrPtr *String
 }
+
+type String string
 
 func TestReadConfigs(t *testing.T) {
 	t.Parallel()
@@ -42,7 +48,77 @@ func TestReadConfigs(t *testing.T) {
 	file := makeTextFile(t)
 	defer os.Remove(file)
 
-	data := dataStruct{
+	data := testData(t, file)
+	testString := strings.TrimSuffix(testString, "\n")
+
+	require.NoError(t, cnfgfile.ReadConfigs(&data, nil), "got an unexpected error")
+	assert.EqualValues(t, testString, data.Address)
+	assert.EqualValues(t, testString, data.Embed.EmbedAddress)
+	assert.EqualValues(t, testString, data.Named.EmbedAddress)
+	assert.EqualValues(t, testString, data.Struct.EmbedAddress)
+	assert.EqualValues(t, testString, data.Strings[1])
+	assert.EqualValues(t, testString, data.Structs[0].EmbedAddress)
+	assert.EqualValues(t, testString, data.Ptructs[0].EmbedAddress)
+	assert.EqualValues(t, testString, data.String)
+	assert.EqualValues(t, testString, data.Etring)
+	assert.EqualValues(t, testString, *data.StrPtr)
+
+	assert.EqualValues(t, testString, data.Map["map_string"])
+	assert.EqualValues(t, "data stuff", data.Map["map2_string"])
+	assert.EqualValues(t, testString, data.MapI[2], "an unexpected change was made to a string")
+	assert.EqualValues(t, "data stuff", data.MapI[5], "an unexpected change was made to a string")
+
+	data.Name = "super:" + file
+	require.NoError(t, cnfgfile.ReadConfigs(&data, &cnfgfile.Opts{Prefix: "super:", MaxSize: 8}))
+	assert.Equal(t, testString[:8], data.Name, "opts.MaxSize doesn't seem to be working")
+}
+
+func TestReadConfigsErrors(t *testing.T) {
+	t.Parallel()
+
+	file := makeTextFile(t)
+	defer os.Remove(file)
+
+	data := testData(t, file)
+	opts := &cnfgfile.Opts{
+		Prefix:  "super:",
+		MaxSize: 8,
+		NoTrim:  true,
+		Name:    "MyThing",
+	}
+
+	require.ErrorIs(t, cnfgfile.ReadConfigs(data, opts), cnfgfile.ErrNotPtr)
+
+	data.Name = "super:/no_file"
+	// This test:
+	// makes sure the correct opts.Prefix is used.
+	// makes sure the proper opts.Name is used.
+	// makes sure a missing file returns a useful error.
+	require.ErrorContains(t, cnfgfile.ReadConfigs(&data, opts),
+		"element failure: MyThing.Name: opening file: open /no_file:",
+		"this may indicate the wrong prefix or name is being used")
+
+	data.Name = ""
+	data.Map["MAPKEY"] = "super:/no_file"
+	require.ErrorContains(t, cnfgfile.ReadConfigs(&data, opts),
+		"element failure: MyThing.Map[MAPKEY]: opening file: open /no_file:",
+		"this may indicate the wrong prefix or name is being used")
+
+	delete(data.Map, "MAPKEY")
+	data.LulWut = map[interface{}][]*Struct{"some_key": {nil, {EmbedName: "super:/no_file"}, nil}}
+	require.ErrorContains(t, cnfgfile.ReadConfigs(&data, opts),
+		"element failure: MyThing.LulWut[some_key][2/3].EmbedName: opening file: open /no_file:",
+		"this test fails is the member names are not concatenated properly")
+}
+
+// testData returns a test struct filled with filepaths.
+// We test strings, structs, maps, slices, pointers...
+func testData(t *testing.T, file string) dataStruct {
+	t.Helper()
+
+	str := String("filepath:" + file)
+
+	return dataStruct{
 		Name:    "me",
 		Address: "filepath:" + file,
 		Embed: struct {
@@ -77,21 +153,10 @@ func TestReadConfigs(t *testing.T) {
 			EmbedName:    "me5",
 			EmbedAddress: "filepath:" + file,
 		}},
+		String: String("filepath:" + file),
+		Etring: String("filepath:" + file),
+		StrPtr: &str,
 	}
-	testString := strings.TrimSuffix(testString, "\n")
-
-	require.NoError(t, cnfgfile.ReadConfigs(&data, nil), "got an unexpected error")
-	assert.EqualValues(t, testString, data.Address)
-	assert.EqualValues(t, testString, data.Embed.EmbedAddress)
-	assert.EqualValues(t, testString, data.Named.EmbedAddress)
-	assert.EqualValues(t, testString, data.Struct.EmbedAddress)
-	assert.EqualValues(t, testString, data.Strings[1])
-	assert.EqualValues(t, testString, data.Structs[0].EmbedAddress)
-	assert.EqualValues(t, testString, data.Ptructs[0].EmbedAddress)
-	assert.EqualValues(t, testString, data.Map["map_string"])
-	assert.EqualValues(t, "data stuff", data.Map["map2_string"])
-	assert.EqualValues(t, testString, data.MapI[2], "an unexpected change was made to a string")
-	assert.EqualValues(t, "data stuff", data.MapI[5], "an unexpected change was made to a string")
 }
 
 func makeTextFile(t *testing.T) string {

--- a/filepath_test.go
+++ b/filepath_test.go
@@ -116,45 +116,45 @@ func TestReadConfigsErrors(t *testing.T) {
 func testData(t *testing.T, file string) dataStruct {
 	t.Helper()
 
-	str := String("filepath:" + file)
+	str := String(cnfgfile.DefaultPrefix + file)
 
 	return dataStruct{
 		Name:    "me",
-		Address: "filepath:" + file,
+		Address: cnfgfile.DefaultPrefix + file,
 		Embed: struct {
 			EmbedName    string
 			EmbedAddress string
 			EmbedNumber  int
 		}{
-			EmbedAddress: "filepath:" + file,
+			EmbedAddress: cnfgfile.DefaultPrefix + file,
 		},
 		Struct: Struct{
 			EmbedName:    "me2",
-			EmbedAddress: "filepath:" + file,
+			EmbedAddress: cnfgfile.DefaultPrefix + file,
 		},
 		Named: &Struct{
 			EmbedName:    "me3",
-			EmbedAddress: "filepath:" + file,
+			EmbedAddress: cnfgfile.DefaultPrefix + file,
 		},
 		Map: map[string]string{
-			"map_string":  "filepath:" + file,
+			"map_string":  cnfgfile.DefaultPrefix + file,
 			"map2_string": "data stuff",
 		},
 		MapI: map[int]string{
-			2: "filepath:" + file,
+			2: cnfgfile.DefaultPrefix + file,
 			5: "data stuff",
 		},
-		Strings: []string{"foo", "filepath:" + file},
+		Strings: []string{"foo", cnfgfile.DefaultPrefix + file},
 		Structs: []Struct{{
 			EmbedName:    "me4",
-			EmbedAddress: "filepath:" + file,
+			EmbedAddress: cnfgfile.DefaultPrefix + file,
 		}},
 		Ptructs: []*Struct{{
 			EmbedName:    "me5",
-			EmbedAddress: "filepath:" + file,
+			EmbedAddress: cnfgfile.DefaultPrefix + file,
 		}},
-		String: String("filepath:" + file),
-		Etring: String("filepath:" + file),
+		String: String(cnfgfile.DefaultPrefix + file),
+		Etring: String(cnfgfile.DefaultPrefix + file),
 		StrPtr: &str,
 	}
 }


### PR DESCRIPTION
Cleaning up from the prior contribution. Adds a few more test cases for the new ReadConfigs code. Completes the `Duration` type. Renames `Changes` to `Opts`.